### PR TITLE
Add explicit conversion of 'specified_keys' to string

### DIFF
--- a/lib/capistrano/tasks/ssh_doctor.rake
+++ b/lib/capistrano/tasks/ssh_doctor.rake
@@ -50,7 +50,7 @@ namespace :ssh do
       specified_keys = fetch(:ssh_options, {})[:keys] || ''
       unless File.exists?(File.expand_path('~/.ssh/id_rsa')) ||
         File.exists?(File.expand_path('~/.ssh/id_dsa')) ||
-        File.exists?(specified_keys)
+        File.exists?(specified_keys.to_s)
         report.report_error_for('local_private_key_exists')
       end
     end


### PR DESCRIPTION
I got the error 'TypeError: no implicit conversion of Array into String' when running `bundle exec cap staging ssh:doctor` as described in Issue #6 .

This seems to be caused by the variable `specified_keys` not being implicitly converted to a string when fed into the function `File.exists`.

I'm not a Rake developer, but after a lot of searching, I found a non-destructive way of feeding the string version of `specified_keys` into 'File.exists' using the `.to_s` method/operator as described here:

[Stackoverflow re: no implicit conversion of array into string](http://stackoverflow.com/questions/30537673/how-to-solve-in-basename-no-implicit-conversion-of-array-into-string)

So, I updated ssh_doctor.rake as described above, and it now works OK, executing test number 2 in the ssh_doctor report correctly. However that is the only test I have done so far.
